### PR TITLE
Tailscale setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,13 @@ services:
       # See https://github.com/qdm12/gluetun-wiki/tree/main/setup#setup
       - VPN_SERVICE_PROVIDER=protonvpn
       - VPN_TYPE=wireguard
-        # Wireguard:
+      # Wireguard:
+      # you can generate the private key here for protonvpn: https://account.proton.me/u/0/vpn/WireGuard
+      # successful settings used: 
+      #   1. choose a name
+      #   2. platform windows
+      #   3. options: disable moderate NAT; enable NAT-PMP (port forwarding); enable VPN Accelerator;
+      #   4. server: Secure Core config server United States (via Switzerland)
       - WIREGUARD_PRIVATE_KEY_SECRETFILE=/run/secrets/protonvpn_wireguard_private_key
       - WIREGUARD_ADDRESSES=10.2.0.2/32
       # Timezone for accurate log times


### PR DESCRIPTION
## Added Services
* Tailscale
  * Tailscale allows me to remotely connect to the containerized services using this new Tailscale dependency from any device that also has Tailscale (namely, my phone)

## Details
* added Tailscale
* moved Overseerr/Radarr/Sonarr behind the Tailscale vpn service

## Todo
Investigate/fix the issue with Tailscale not recognizing the Secret file. When authentication fails, it logs an auth link to the console that you can use to authenticate it anyways, so it's not that big a deal. But it would be much nicer if it just worked.