### PR TITLE
switch port manager to mjmeli API-based image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@
 # Options: disable moderate NAT; enable NAT-PMP (port forwarding); enable VPN Accelerator
 WG_PRIVATE_KEY=your_private_key_here
 
+# Gluetun API Key
+# Used for managing the gluetun control server
+# Generate with `docker run --rm qmcgaw/gluetun genkey`
+GLUETUN_API_KEY=your_gluetun_api_key_here
+
 # qBittorrent Credentials
 QBITTORRENT_USER=your_username
 QBITTORRENT_PASS=your_password

--- a/services/gluetun-qbittorrent-port-manager.yml
+++ b/services/gluetun-qbittorrent-port-manager.yml
@@ -1,19 +1,15 @@
 services:
   gluetun-qbittorrent-port-manager:
-    image: snoringdragon/gluetun-qbittorrent-port-manager:latest
+    image: mjmeli/qbittorrent-port-forward-gluetun-server
     restart: unless-stopped
     container_name: gt-port-manager
     network_mode: "service:gluetun"
-    volumes:
-      - C:\MEDIA_AUTOMATION\Gluetun:/gluetun
     depends_on:
       gluetun:
         condition: service_healthy
     environment:
-      - QBITTORRENT_SERVER=localhost
-      - QBITTORRENT_PORT=8080
-      - QBITTORRENT_USER=${QBITTORRENT_USER}
-      - QBITTORRENT_PASS=${QBITTORRENT_PASS}
-      - PORT_FORWARDED=/gluetun/forwarded_port
-      - HTTP_S=http # Select 'http' or 'https' depending on if you use certificates.
-      - TZ=America/Chicago
+      - QBT_USERNAME=${QBITTORRENT_USER}
+      - QBT_PASSWORD=${QBITTORRENT_PASS}
+      - QBT_ADDR=http://localhost:8080
+      - GTN_ADDR=http://localhost:8000
+      - GTN_APIKEY=${GLUETUN_API_KEY}

--- a/services/gluetun.yml
+++ b/services/gluetun.yml
@@ -31,3 +31,4 @@ services:
       - WIREGUARD_ADDRESSES=10.2.0.2/32
       - DNS_ADDRESS=10.2.0.1
       - LOG_LEVEL=info
+      - HTTP_CONTROL_SERVER_AUTH_DEFAULT_ROLE={"auth":"apikey","apikey":"${GLUETUN_API_KEY}"}


### PR DESCRIPTION
The snoringdragon image uses inotifywait to detect port file changes, which doesn't work on Windows Docker bind mounts. Replaced with mjmeli/qbittorrent-port-forward-gluetun-server which polls gluetun's control server API instead, and added API key auth to gluetun.