### PR TITLE
Serve smokeping graphs as static PNGs instead of proxying the app through the funnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ serve configs are stored in the repo alongside their service compose files and m
 - `TS_AUTHKEY` in `.env` is only read the first time a sidecar registers; existing sidecars auth from their state dirs. tailscale auth keys expire (90 days max), so mint a fresh reusable key at https://login.tailscale.com/admin/settings/keys before adding a new sidecar.
 - tailscale serve's go reverse proxy silently drops semicolon-separated query params. old cgi apps like smokeping use `;` as a query separator — use `&` instead in any url that goes through a sidecar (smokeping accepts both).
 - serve path handlers strip the mount prefix before proxying (`/smokeping/foo` reaches the backend as `/foo`). if the backend expects the prefix, repeat it in the proxy target: `"/smokeping/": {"Proxy": "http://ts-smokeping:80/smokeping/"}`.
-- a serve handler can proxy to another container over the docker network (e.g. ts-homepage proxying `/smokeping/` to `ts-smokeping:80`). this is how a tailnet-only service can be surfaced through an already-funneled host without funneling it separately — and how the homepage smokeping widget stays a relative url that works both on- and off-tailnet.
+- a serve handler can proxy to another container over the docker network (e.g. `"/foo/": {"Proxy": "http://ts-foo:80/foo/"}`), which surfaces a tailnet-only service through an already-funneled host without funneling it separately. **be careful doing this from a funneled host** — serve matches on path prefix only and cannot see query strings, so you publish the backend's *entire* http surface, not the one page you had in mind. ts-homepage used to proxy `/smokeping/` this way and it put the whole smokeping ui on the public internet; see "publishing a graph without publishing the app" below for what replaced it.
 - older `tailscale serve` clis refused non-localhost proxy targets outright ("only localhost or 127.0.0.1 proxies are currently supported", [tailscale#8751](https://github.com/tailscale/tailscale/issues/8751), still open as a feature request about custom domains). that restriction is gone: as of 1.98 the cli accepts a non-localhost host so long as the target includes a scheme (the only related error left in the binary is `non-localhost target %q must include a scheme`), and the `TS_SERVE_CONFIG` json path never enforced it. so cross-container handlers are supported outright, not a loophole.
 
 ## sidecar for a service that already has a network namespace (qbittorrent)
@@ -101,6 +101,16 @@ the smokeping target list lives in the repo at `services/smokeping/smokeping-con
 the funnel targets contain the tailnet hostname literally. smokeping's config format has no variable interpolation, and the domain is already present in this repo's git history, so the placeholder-plus-render-script indirection that briefly lived here bought nothing and has been removed.
 
 removing a target leaves its `.rrd` data file behind in `${CONFIG_ROOT}/SmokePing/data/` (harmless); re-adding a target at the same path resumes its history.
+
+## publishing a graph without publishing the app
+
+homepage is funneled, so anything it proxies is on the public internet. tailscale serve matches on path prefix and cannot see query strings, and smokeping serves a graph (`displaymode=a`) and its whole browsable ui (`displaymode=n`) from the same `/smokeping/` path — so there is no serve config that exposes one without the other. proxying it published every target, the LAN addressing scheme, and the ISP first hop.
+
+instead, `smokeping-graph-snapshot` (a ~7MB busybox loop in `services/smokeping/smokeping.yml`) fetches the two dashboard graphs every 300s and writes them to `${CONFIG_ROOT}/Homepage/graphs`, which homepage mounts at `/app/public/graphs` and serves as static files. the widgets point at `/graphs/funnel-latency.png` and `/graphs/isp-latency.png`, so exactly two immutable paths are public with no query string to manipulate. smokeping itself is reachable only on the tailnet (`https://smokeping.<your-tailnet>.ts.net`) and on the LAN (`:8085`), which is where the tiles' click-through links go.
+
+no freshness is lost — the probe step is 300s, so a live request could not show anything newer than the snapshot.
+
+two deliberate details: the fetch writes to a temp file and renames it, so a failed or partial fetch can never replace a good graph with a truncated one; and the container's healthcheck fails if either png goes older than 15 minutes, so a dead snapshotter shows up as an unhealthy container instead of a silently frozen graph.
 
 ## the Tailnet section
 
@@ -141,7 +151,7 @@ order matters — the app is stranded until it restarts too. use `restart`, not 
 docker exec ts-qbittorrent wget -qO /dev/null http://gluetun:8080/
 ```
 
-if the dashboard graph itself is what's slow, don't try to read it through the funnel — smokeping is published straight onto the LAN, bypassing every sidecar:
+if it's `ts-homepage` that has degraded, the dashboard carrying the graph is itself slow to load (the graph is a static png, so slowness there is the funnel path, never smokeping). read smokeping directly instead — it's published onto the LAN, bypassing every sidecar, and unlike the dashboard tiles this gives you the full interactive ui:
 
 ```
 http://<vm-ip>:8085/smokeping/?displaymode=a&start=-24h&end=now&target=Tailnet.AllFunnels

--- a/README.md
+++ b/README.md
@@ -110,7 +110,15 @@ instead, `smokeping-graph-snapshot` (a ~7MB busybox loop in `services/smokeping/
 
 no freshness is lost — the probe step is 300s, so a live request could not show anything newer than the snapshot.
 
-two deliberate details: the fetch writes to a temp file and renames it, so a failed or partial fetch can never replace a good graph with a truncated one; and the container's healthcheck fails if either png goes older than 15 minutes, so a dead snapshotter shows up as an unhealthy container instead of a silently frozen graph.
+three deliberate details: the fetch writes to a temp file and renames it, so a failed or partial fetch can never replace a good graph with a truncated one; it checks the png magic bytes first, because smokeping answers `200` with an html error page for a bad target and that would otherwise be promoted to a "fresh" graph; and the container's healthcheck fails if either png goes older than 15 minutes, so a dead snapshotter shows up as an unhealthy container instead of a silently frozen graph.
+
+**anything added to the snapshot list is published to the public internet**, so its `title` in `Targets` must not contain an address — smokeping renders the title into the image. (`host` is fine; it is never drawn.) this is why `ISP.FirstHop`'s title no longer carries the hop address. the LAN targets still do, which is safe only because they aren't snapshotted.
+
+on a fresh deploy, create the output directory before first start — the snapshotter runs as `1000:1000` and cannot chown a bind mount that docker auto-creates as root:
+
+```
+mkdir -p ${CONFIG_ROOT}/Homepage/graphs && chown 1000:1000 ${CONFIG_ROOT}/Homepage/graphs
+```
 
 ## the Tailnet section
 

--- a/services/homepage/homepage-config/services.yaml
+++ b/services/homepage/homepage-config/services.yaml
@@ -151,18 +151,19 @@
 
         - Smokeping:
             icon: smokeping.png
-            # NOTE: use & (not smokeping's usual ;) as the query separator — tailscale
-            # serve's Go reverse proxy strips semicolon-separated query params entirely.
-            # relative urls: smokeping is path-proxied through the homepage origin
-            # (ts-homepage serve config) so the widget also works via funnel from
-            # outside the tailnet, where smokeping's own hostname doesn't resolve.
-            href: /smokeping/?displaymode=n&start=-3h&end=now&target=ISP.FirstHop
-            description: Smokeping graphs network latency over time
+            # the graph is a static PNG written by smokeping-graph-snapshot and served
+            # from homepage's own /app/public, NOT proxied from smokeping. homepage is
+            # funneled, and tailscale serve can't distinguish a graph request from the
+            # whole browsable UI (same path, different query), so proxying the cgi here
+            # published every target, the LAN addressing scheme and the ISP first hop.
+            # href goes to the real UI, which is tailnet-only by design.
+            href: https://smokeping.{{HOMEPAGE_VAR_TS_DOMAIN}}/
+            description: Network latency over time (interactive UI is tailnet-only)
             ping: http://ts-smokeping:80
             widget:
               type: iframe
               name: smokeping-latency
-              src: /smokeping/?displaymode=a&start=-3h&end=now&target=ISP.FirstHop
+              src: /graphs/isp-latency.png
               allowScrolling: no
               refreshInterval: 300000
 
@@ -172,14 +173,14 @@
             # per-service funnel graphs into one chart without probing anything itself.
             # 24h window (not 3h like the graph above) because sidecar DERP degradation
             # comes on slowly — a short window shows it as flat-high with no baseline.
-            # same url rules as the Smokeping widget above: relative path, & separators.
-            href: /smokeping/?displaymode=n&start=-24h&end=now&target=Tailnet.AllFunnels
+            # static PNG, same reasoning as the Smokeping widget above.
+            href: https://smokeping.{{HOMEPAGE_VAR_TS_DOMAIN}}/
             description: Tailscale funnel response time — one line diverging means that sidecar needs a restart
             ping: http://ts-smokeping:80
             widget:
               type: iframe
               name: funnel-latency
-              src: /smokeping/?displaymode=a&start=-24h&end=now&target=Tailnet.AllFunnels
+              src: /graphs/funnel-latency.png
               allowScrolling: no
               refreshInterval: 300000
 

--- a/services/homepage/homepage-config/services.yaml
+++ b/services/homepage/homepage-config/services.yaml
@@ -171,8 +171,9 @@
             icon: tailscale.png
             # Tailnet.AllFunnels is a smokeping multihost target: it overlays the three
             # per-service funnel graphs into one chart without probing anything itself.
-            # 24h window (not 3h like the graph above) because sidecar DERP degradation
-            # comes on slowly — a short window shows it as flat-high with no baseline.
+            # snapshotted over 24h (the ISP graph above uses 3h) because sidecar DERP
+            # degradation comes on slowly — a short window shows it as flat-high with
+            # no baseline to compare against. windows live in GRAPHS in smokeping.yml.
             # static PNG, same reasoning as the Smokeping widget above.
             href: https://smokeping.{{HOMEPAGE_VAR_TS_DOMAIN}}/
             description: Tailscale funnel response time — one line diverging means that sidecar needs a restart

--- a/services/homepage/homepage.yml
+++ b/services/homepage/homepage.yml
@@ -20,6 +20,7 @@ services:
     volumes:
       - ./homepage-config:/app/config
       - /mnt/storage/media:/media:ro
+      - ${CONFIG_ROOT}/Homepage/graphs:/app/public/graphs:ro # static smokeping graphs, written by smokeping-graph-snapshot; served at /graphs/*.png
     env_file:
       - ./homepage.env
     environment:

--- a/services/homepage/ts-homepage-config/serve-config.json
+++ b/services/homepage/ts-homepage-config/serve-config.json
@@ -9,9 +9,6 @@
       "Handlers": {
         "/": {
           "Proxy": "http://127.0.0.1:3000"
-        },
-        "/smokeping/": {
-          "Proxy": "http://ts-smokeping:80/smokeping/"
         }
       }
     }

--- a/services/smokeping/smokeping-config/Targets
+++ b/services/smokeping/smokeping-config/Targets
@@ -259,7 +259,12 @@ title = ISP
 
 ++ FirstHop
 menu = First Hop
-title = ISP first hop past the router (72.8.112.2)
+# NOTE: this target is snapshotted to a PUBLIC png (see smokeping-graph-snapshot in
+# smokeping.yml). smokeping renders `title` into the image, so the title must not
+# contain an address. any target added to the snapshot list needs the same treatment —
+# this is a security property of this file now, not a cosmetic choice. `host` is safe:
+# it is never drawn into the graph.
+title = ISP first hop past the router
 host = 72.8.112.2
 
 + Tailnet

--- a/services/smokeping/smokeping.yml
+++ b/services/smokeping/smokeping.yml
@@ -27,3 +27,53 @@ services:
       - ./smokeping-config/Targets:/config/Targets # repo-managed; shadows the CONFIG_ROOT copy
       - ${CONFIG_ROOT}/SmokePing/data:/data
     restart: unless-stopped
+
+  # Snapshots the two dashboard graphs to static PNGs that homepage serves itself.
+  # Why: homepage is funneled (public), and tailscale serve matches on path prefix only —
+  # it can't tell `displaymode=a` (a graph) from `displaymode=n` (the whole browsable UI),
+  # since both are `/smokeping/`. Proxying the CGI publicly therefore exposed the entire
+  # smokeping site: every target, the LAN addressing scheme, and the ISP first hop.
+  # Serving pre-rendered images instead means exactly two immutable paths are public,
+  # with no query string to manipulate. Costs nothing in freshness: the probe step is
+  # 300s, so a live request could never show anything newer than this snapshot.
+  smokeping-graph-snapshot:
+    image: busybox:1.37
+    container_name: smokeping-graph-snapshot
+    user: "1000:1000"
+    read_only: true
+    depends_on:
+      ts-smokeping:
+        condition: service_healthy
+    volumes:
+      - ${CONFIG_ROOT}/Homepage/graphs:/out
+    command:
+      - sh
+      - -c
+      - |
+        while :; do
+          ok=1
+          for pair in funnel-latency=Tailnet.AllFunnels isp-latency=ISP.FirstHop; do
+            name=$${pair%%=*}
+            target=$${pair#*=}
+            # write to a temp file and rename, so a failed or partial fetch can never
+            # replace a good graph with a truncated one
+            if wget -qO "/out/.$$name.tmp" \
+                 "http://ts-smokeping:80/smokeping/?displaymode=a&start=-24h&end=now&target=$$target"; then
+              mv "/out/.$$name.tmp" "/out/$$name.png"
+            else
+              ok=0
+              rm -f "/out/.$$name.tmp"
+            fi
+          done
+          # back off briefly on failure so a cold start doesn't wait a full step
+          if [ "$$ok" = 1 ]; then sleep 300; else sleep 30; fi
+        done
+    # a dead snapshotter would otherwise show a silently frozen graph forever; fail the
+    # container instead once either PNG goes stale
+    healthcheck:
+      test: ["CMD", "sh", "-c", "test $$(find /out -name '*.png' -mmin -15 | wc -l) -eq 2"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
+    restart: unless-stopped

--- a/services/smokeping/smokeping.yml
+++ b/services/smokeping/smokeping.yml
@@ -50,26 +50,40 @@ services:
       - sh
       - -c
       - |
+        # name:target:window — keep this list in sync with the healthcheck's expected
+        # count below. every target listed here is published PUBLICLY as a png, so its
+        # `title` in the Targets file must not contain an address (smokeping draws the
+        # title into the image).
+        GRAPHS='funnel-latency:Tailnet.AllFunnels:-24h isp-latency:ISP.FirstHop:-3h'
         while :; do
           ok=1
-          for pair in funnel-latency=Tailnet.AllFunnels isp-latency=ISP.FirstHop; do
-            name=$${pair%%=*}
-            target=$${pair#*=}
-            # write to a temp file and rename, so a failed or partial fetch can never
-            # replace a good graph with a truncated one
-            if wget -qO "/out/.$$name.tmp" \
-                 "http://ts-smokeping:80/smokeping/?displaymode=a&start=-24h&end=now&target=$$target"; then
-              mv "/out/.$$name.tmp" "/out/$$name.png"
+          for spec in $$GRAPHS; do
+            name=$${spec%%:*}
+            rest=$${spec#*:}
+            target=$${rest%%:*}
+            window=$${rest#*:}
+            tmp="/out/.$$name.tmp"
+            # -T 30 so a stalled fetch can't wedge the loop past its own cycle.
+            # a 200 is not proof of a graph: smokeping answers 200 with an html error
+            # page for a bad target, so check the png magic bytes before promoting.
+            # write-then-rename means a bad fetch can never replace a good graph.
+            if wget -q -T 30 -O "$$tmp" \
+                 "http://ts-smokeping:80/smokeping/?displaymode=a&start=$$window&end=now&target=$$target" \
+               && [ -s "$$tmp" ] \
+               && head -c 8 "$$tmp" | od -An -tx1 | grep -q '89 50 4e 47'; then
+              mv "$$tmp" "/out/$$name.png"
             else
               ok=0
-              rm -f "/out/.$$name.tmp"
+              rm -f "$$tmp"
+              echo "snapshot failed: $$name ($$target)"
             fi
           done
           # back off briefly on failure so a cold start doesn't wait a full step
           if [ "$$ok" = 1 ]; then sleep 300; else sleep 30; fi
         done
     # a dead snapshotter would otherwise show a silently frozen graph forever; fail the
-    # container instead once either PNG goes stale
+    # container instead once either PNG goes stale.
+    # the `-eq 2` must match the number of entries in GRAPHS above.
     healthcheck:
       test: ["CMD", "sh", "-c", "test $$(find /out -name '*.png' -mmin -15 | wc -l) -eq 2"]
       interval: 60s


### PR DESCRIPTION
## Why

`ts-homepage` is funneled, and it proxied `/smokeping/` to `ts-smokeping:80`. That put the **entire** Smokeping UI on the public internet — the whole target tree, the LAN addressing scheme (router, `pve-1`, the Plex LXC) and the ISP first hop, all fetchable anonymously.

Verified by resolving the funnel ingress IP directly with `--resolve`, no tailnet membership and no home network involved:

```
/smokeping/?target=LAN.Router     200   192.168.1.1
/smokeping/?target=LAN.pve1       200   192.168.1.205
/smokeping/?target=LAN.Plex       200   192.168.1.176
/smokeping/?target=ISP.FirstHop   200   ISP first hop past the router (72.8.112.2)
```

This predates the funnel-latency widget — the handler was added in `ae47d2b` (2026-07-15) "for funnel access". The widget just gave a reason to click it.

## Why there's no serve-config fix

- Tailscale serve matches on **path prefix** and cannot see query strings.
- Smokeping serves the graph (`displaymode=a`) and the browsable UI (`displaymode=n`) from the same `/smokeping/` path.
- `AllowFunnel` is **per-origin, not per-path**, so the handler can't be excluded from the funnel while the dashboard stays public.
- No `imgcache` is configured, so the PNG is CGI-generated rather than a static file that could be proxied on its own path.

Requirements were: keep `AllowFunnel`, keep the graph visible publicly, expose nothing else of Smokeping. Nothing in serve config satisfies all three.

## What this does

Stops proxying Smokeping. `smokeping-graph-snapshot` — a ~7MB busybox loop — fetches the two dashboard graphs every 300s into `${CONFIG_ROOT}/Homepage/graphs`, which homepage mounts read-only at `/app/public/graphs` and serves as static files. Widgets point at `/graphs/funnel-latency.png` and `/graphs/isp-latency.png`.

Exactly two immutable public paths, no query string to manipulate. **No freshness is lost** — the probe step is 300s, so a live request could never show anything newer.

The tiles' click-through links now go to `https://smokeping.<tailnet>/`, which is tailnet-only. Graphs are visible from anywhere; the interactive UI requires the tailnet, which is the intended outcome.

## Failure modes handled up front

- **Atomic write.** The fetch writes to a temp file and renames, so a failed or partial fetch can never replace a good graph with a truncated one — the same shape as the render-script bug in #55.
- **Staleness guard.** The healthcheck fails if either PNG ages past 15 minutes, so a dead snapshotter surfaces as an unhealthy container rather than a silently frozen graph. All three states tested: fresh → pass, one stale → fail, both missing → fail.

## Verified after the change

| | |
|---|---|
| `/graphs/funnel-latency.png` | `200 image/png` 34,846 bytes |
| `/graphs/isp-latency.png` | `200 image/png` 57,007 bytes |
| every `/smokeping/*` path | `308` → `404`, **no address in the final body** |
| `/` (dashboard) | `200`, still public |
| smokeping on tailnet | `smokeping.<tailnet>` reachable, tailnet-only |
| smokeping on LAN | `:8085/smokeping/` → `200`, full UI |
| containers | 28/28, snapshotter healthy |
| `scripts/list-ports.sh` | unchanged |

The 308s are Next.js trailing-slash normalization landing on a 404 — I followed them rather than treating a redirect as a denial, and confirmed the body leaks nothing.

## Also

Corrected the README gotcha that recommended cross-container serve handlers without warning that from a **funneled** host they publish the backend's entire HTTP surface. That advice is what produced this exposure.
