### PR TITLE
smokeping - force public DNS on funnel probe so it measures the real ingress path

### DIFF
--- a/services/smokeping/smokeping-config/Targets
+++ b/services/smokeping/smokeping-config/Targets
@@ -281,7 +281,14 @@ remark = End-to-end https response time through the tailscale funnel (public pat
 probe = Curl
 # Curl.pm never passes -s, so without this every probe writes a progress meter to
 # stderr — ~78% of `docker logs smokeping` and ~1.9MB/day into an uncapped json-file log.
-extraargs = -s
+# --dns-servers forces resolution through a public resolver instead of the container's own
+# (which can hand back the tailnet 100.x address for these funnel hosts). Without it the
+# probe occasionally connects node-to-node over the tailnet (~6ms) instead of the public
+# funnel ingress (~350ms), silently under-reporting and masking funnel health — a low
+# reading would no longer prove the public path works. This bit us on CalibreFunnel (July
+# 2026): an ~11h dip to ~6ms with 0 loss was the probe taking the tailnet shortcut, not an
+# outage. -4 pins IPv4 to keep the series continuous with the pre-fix history.
+extraargs = -s -4 --dns-servers 1.1.1.1,8.8.8.8
 
 ++ HomepageFunnel
 menu = Homepage

--- a/services/smokeping/smokeping-config/Targets
+++ b/services/smokeping/smokeping-config/Targets
@@ -279,15 +279,11 @@ remark = End-to-end https response time through the tailscale funnel (public pat
          this probe times the tls+transport path, and a small error page exercises \
          it without pulling the 40KB dashboard five times per cycle.
 probe = Curl
-# Curl.pm never passes -s, so without this every probe writes a progress meter to
+# `-s`: silent. Without this flag, every probe writes a progress meter to
 # stderr — ~78% of `docker logs smokeping` and ~1.9MB/day into an uncapped json-file log.
-# --dns-servers forces resolution through a public resolver instead of the container's own
-# (which can hand back the tailnet 100.x address for these funnel hosts). Without it the
-# probe occasionally connects node-to-node over the tailnet (~6ms) instead of the public
-# funnel ingress (~350ms), silently under-reporting and masking funnel health — a low
-# reading would no longer prove the public path works. This bit us on CalibreFunnel (July
-# 2026): an ~11h dip to ~6ms with 0 loss was the probe taking the tailnet shortcut, not an
-# outage. -4 pins IPv4 to keep the series continuous with the pre-fix history.
+# `--dns-servers` forces the ping to resolve through the public internet
+# route. Otherwise it can silently fall back to resolving locally.
+# `-4` pins IPv4 to keep the series continuous with the pre-fix history.
 extraargs = -s -4 --dns-servers 1.1.1.1,8.8.8.8
 
 ++ HomepageFunnel


### PR DESCRIPTION
## What

Adds `-4 --dns-servers 1.1.1.1,8.8.8.8` to the `extraargs` of the shared `Curl` probe under `+ Tailnet`, so all three funnel targets (Homepage/Komga/Calibre) always resolve to the **public funnel ingress** instead of possibly taking a direct tailnet path.

## Why

The probe runs on the `ts-smokeping` tailnet node, co-located with the funnel sidecars on the same docker bridge (`172.18.0.0/16`). Each target is reachable both via the public funnel ingress (`208.111.x`, ~350ms) and directly over the tailnet (`100.x`, ~6ms). When resolution returned the tailnet address, the probe silently measured the ~6ms shortcut at **0 loss** — a great-looking number that isn't the public path and can mask a real funnel problem.

This bit `CalibreFunnel` in July 2026: an ~11h dip from ~350ms to ~6ms (0 loss, no container restart, calibre-only). Investigation confirmed nothing was wrong with calibre — the probe had just taken the shortcut.

## Design notes

- Forced-public-DNS chosen over hardcoding ingress IPs so it survives Tailscale rotating those addresses; an unreachable resolver fails visibly as loss rather than silently under-reporting.
- `-4` keeps the series on IPv4 for continuity with pre-fix history.
- Image curl is built with c-ares/AsynchDNS, so `--dns-servers` is supported.

## Verification

Live-tested on the running daemon via `smokeping --debug --filter=/Tailnet/CalibreFunnel` — confirmed the built command includes `--dns-servers 1.1.1.1,8.8.8.8` and all pings measure the public path (~0.37s median), matching Homepage/Komga. Smokeping was restarted to load the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)